### PR TITLE
Rdesai/disable eeprom

### DIFF
--- a/disable_eeprom_read.patch
+++ b/disable_eeprom_read.patch
@@ -1,0 +1,12 @@
+--- a/bootloader/t186ref/BCT/tegra234-mb2-bct-misc-p3767-0000.dts	2023-09-15 10:49:42.201358408 -0500
++++ b/bootloader/t186ref/BCT/tegra234-mb2-bct-misc-p3767-0000.dts	2023-09-15 10:49:34.304026616 -0500
+@@ -10,7 +10,7 @@
+ 			cvm_eeprom_read_size = <0x100>;
+ 			cvb_eeprom_i2c_instance = <0x0>;
+ 			cvb_eeprom_i2c_slave_address = <0xae>;
+-			cvb_eeprom_read_size = <0x100>;
++			cvb_eeprom_read_size = <0x0>;
+ 		};
+ 	};
+ };
+\ No newline at end of file

--- a/flash-tools.nix
+++ b/flash-tools.nix
@@ -35,7 +35,7 @@ let
       perl
     ];
 
-    patches = [ ./flash-tools.patch ./flash-tools-secureboot.patch ];
+    patches = [ ./flash-tools.patch ./flash-tools-secureboot.patch ./disable_eeprom_read.patch ];
 
     postPatch = ''
       # Needed in Jetpack 5

--- a/kernel/default.nix
+++ b/kernel/default.nix
@@ -134,6 +134,8 @@ in pkgsAarch64.buildLinux (args // {
     # TODO: Disable Tegra SE use for now because it causes kernel errors when used
     # See https://github.com/anduril/jetpack-nixos/issues/114
     DEV_TEGRA_SE_USE_HOST1X_INTERFACE = no;
+
+    CONFIG_USB_TEGRA_XUDC = yes;
   } // (lib.optionalAttrs realtime {
     PREEMPT_VOLUNTARY = lib.mkForce no; # Disable the one set in common-config.nix
     # These are the options enabled/disabled by scripts/rt-patch.sh


### PR DESCRIPTION
###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->
- remove EEPROM for use with ant micro carrier board
- enable `tegra_xudc` driver

Placeholder until we upstream these changes.

###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
