### PR TITLE
fix patch url ref

### DIFF
--- a/l4t.nix
+++ b/l4t.nix
@@ -145,7 +145,7 @@ let
   _l4t-multimedia-v4l = libv4l.overrideAttrs ({ nativeBuildInputs ? [], patches ? [], postPatch ? "", ... }: {
     nativeBuildInputs = nativeBuildInputs ++ [ dpkg ];
     patches = patches ++ lib.singleton (fetchpatch {
-      url = "https://raw.githubusercontent.com/OE4T/meta-tegra/master/recipes-multimedia/libv4l2/libv4l2-minimal/0003-Update-conversion-defaults-to-match-NVIDIA-sources.patch";
+      url = "https://raw.githubusercontent.com/OE4T/meta-tegra/85aa94e16104debdd01a3f61a521b73d86340a9f/recipes-multimedia/libv4l2/libv4l2-minimal/0003-Update-conversion-defaults-to-match-NVIDIA-sources.patch";
       sha256 = "sha256-vGilgHWinrKjX+ikHo0J20PL713+w+lv46dBgfdvsZM=";
     });
     # Use a placeholder path that we replace in the l4t-multimedia derivation, We avoid an infinite recursion problem this way.


### PR DESCRIPTION
###### Description of changes

<!--
What has changed as a result of this PR? Why was the change made?
-->
See https://github.com/anduril/jetpack-nixos/pull/187

Patch cannot be applied directly to our fork of master. This is temporary until 35.4.1 rollout.
###### Testing

<!--
If applicable, please mention what was done to test this change.
What SoM and carrier board was this change tested on? e.g. Xavier AGX devkit
-->
